### PR TITLE
fix: disallow usage of [0-9].x.x branches

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,6 +1,6 @@
 branches:
   - 'main'
-  - '+([0-9])?(.{+([0-9]),x}).x'
+  - '+([0-9])?(.{+([0-9])}).x'
   - name: next
     channel: next
   - name: beta


### PR DESCRIPTION
Signed-off-by: Moritz Wiesinger <moritz.wiesinger@dynatrace.com>